### PR TITLE
Remove redirect_uri from profile method call

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,6 @@ get '/callback' do
   profile = WorkOS::SSO.profile(
     code: params['code'],
     project_id: PROJECT_ID,
-    redirect_uri: REDIRECT_URI
   )
 
   session[:user] = profile.to_json


### PR DESCRIPTION
The latest version of our SDKs removed the redirect uri from the token exchange per OAuth spec. This updates the demo app to do the same